### PR TITLE
Switch to system_alert_window plugin

### DIFF
--- a/lib/features/games/idle_games/overlay_window.dart
+++ b/lib/features/games/idle_games/overlay_window.dart
@@ -1,18 +1,22 @@
-import 'package:flutter_overlay_window/flutter_overlay_window.dart';
+import 'package:system_alert_window/system_alert_window.dart';
 
 class OverlayControls {
   static Future<void> show() async {
-    await FlutterOverlayWindow.showOverlay(
+    await SystemAlertWindow.showSystemWindow(
       height: 300,
       width: 300,
-      alignment: OverlayAlignment.center,
-      flag: OverlayFlag.defaultFlag,
-      overlayTitle: "Script Controls",
-      overlayContent: "Control your script",
+      header: SystemWindowHeader(title: SystemWindowText(text: "Script Controls")),
+      body: SystemWindowBody(
+        rows: [
+          EachRow(columns: [
+            EachColumn(text: SystemWindowText(text: "Control your script"))
+          ])
+        ],
+      ),
     );
   }
 
   static Future<void> hide() async {
-    await FlutterOverlayWindow.closeOverlay();
+    await SystemAlertWindow.closeSystemWindow();
   }
 }

--- a/lib/features/games/idle_games/presentation/screens/idle_games_screen.dart
+++ b/lib/features/games/idle_games/presentation/screens/idle_games_screen.dart
@@ -1,6 +1,6 @@
 import 'dart:developer';
 import 'package:flutter/material.dart';
-import 'package:flutter_overlay_window/flutter_overlay_window.dart';
+import 'package:system_alert_window/system_alert_window.dart';
 import '../../../../../shared/widgets/game_enable_container.dart';
 import '../../overlay_window.dart';
 import '../../../../../shared/widgets/permission_screen_layout.dart';
@@ -22,9 +22,9 @@ class IdleGamesScreen extends StatelessWidget {
           title: 'Idle Games AI Model',
           onEnable: () async {
             log("Enabled");
-            if (!await FlutterOverlayWindow.isPermissionGranted()) {
+            if (!await SystemAlertWindow.checkPermissions) {
               log("Requesting permission for overlay");
-              await FlutterOverlayWindow.requestPermission();
+              await SystemAlertWindow.requestPermissions();
             }
             await OverlayControls.show();
             log("Not Requesting permission for overlay");

--- a/lib/shared/widgets/permission_screen_layout.dart
+++ b/lib/shared/widgets/permission_screen_layout.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_overlay_window/flutter_overlay_window.dart';
+import 'package:system_alert_window/system_alert_window.dart';
 import 'package:gooner_play/shared/widgets/permission_status_container.dart';
 import 'package:gooner_play/shared/widgets/game_enable_container.dart';
 
@@ -53,7 +53,7 @@ class _PermissionScreenLayoutState extends State<PermissionScreenLayout>
   }
 
   Future<void> _checkPermissions() async {
-    final layout = await FlutterOverlayWindow.isPermissionGranted();
+    final layout = await SystemAlertWindow.checkPermissions;
     setState(() {
       _layoutPermission = layout;
     });

--- a/lib/shared/widgets/permission_status_container.dart
+++ b/lib/shared/widgets/permission_status_container.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_overlay_window/flutter_overlay_window.dart';
+import 'package:system_alert_window/system_alert_window.dart';
 
 class PermissionStatusContainer extends StatefulWidget {
   const PermissionStatusContainer({super.key});
@@ -36,7 +36,7 @@ class _PermissionStatusContainerState extends State<PermissionStatusContainer>
   }
 
   Future<void> _checkPermissions() async {
-    final overlay = await FlutterOverlayWindow.isPermissionGranted();
+    final overlay = await SystemAlertWindow.checkPermissions;
     setState(() {
       _overlayPermission = overlay;
     });
@@ -48,7 +48,7 @@ class _PermissionStatusContainerState extends State<PermissionStatusContainer>
       );
 
   Future<void> _openOverlayPermissionSettings() async {
-    await FlutterOverlayWindow.requestPermission();
+    await SystemAlertWindow.requestPermissions();
     await _checkPermissions();
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -126,14 +126,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
-  flutter_overlay_window:
+  system_alert_window:
     dependency: "direct main"
     description:
-      name: flutter_overlay_window
-      sha256: "17988420249da68e421d1b44b511e6113d3de7a9e52c3fbd6d99730508af4580"
+      name: system_alert_window
+      sha256: ""
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "2.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
-  flutter_overlay_window: ^0.5.0
+  system_alert_window: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- replace flutter_overlay_window with system_alert_window dependency
- update overlay helper code and permission widgets

## Testing
- `flutter format lib` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b28cbb6908332be289a5ee73a1ce4